### PR TITLE
CI: show Central Time in update badge

### DIFF
--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set current date as env variable
-        run: echo "builddate=$(date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_OUTPUT
+        run: echo "builddate=$(TZ=America/Chicago date +'%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_OUTPUT
         id: date
 
       - name: Update Shielded.dev Badge


### PR DESCRIPTION
Formats the update badge timestamp in the America/Chicago time zone and includes the timezone abbreviation. The badge will show CDT during daylight saving time and CST during standard time.