### PR TITLE
Chore: mark generated assets for Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # Generated browser and templ output
 pages/*_templ.go linguist-generated=true
 static/main.js linguist-generated=true
-static/style/style.css linguist-generated=true
+static/style/** linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Generated browser and templ output
+pages/*_templ.go linguist-generated=true
+static/main.js linguist-generated=true
+static/style/style.css linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # Generated browser and templ output
-pages/*_templ.go linguist-generated=true
-static/main.js linguist-generated=true
-static/style/** linguist-generated=true
+/pages/*_templ.go linguist-generated=true
+/static/main.js linguist-generated=true
+/static/style/** linguist-generated=true


### PR DESCRIPTION
Marks committed generated frontend and templ output as linguist-generated so GitHub excludes it from source language statistics and generated-file diffs.