### PR TITLE
Feat: serve shields by user key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ go test ./...                              # compile/test all Go packages
 ### Go
 
 - Run `gofmt` on each changed Go file and preserve the existing package split: root package `shieldeddotdev` contains HTTP/application behavior, while `model` contains database access.
+- Prefer returning an error from helpers instead of handling it there. Let the caller add context, log the error, and choose the response.
 - Keep route setup in `cmd/shielded/main.go`; keep request parsing/validation and HTTP responses in the applicable handler.
 - Use parameterized SQL through `database/sql`, as the mappers do. Shield reads and writes must preserve the ownership checks used by the dashboard handlers.
 - Do not change public JSON field names or badge URL shapes casually. The dashboard, embedded Markdown, and external clients depend on the exported Go/TypeScript field names and host-specific routes.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,7 +90,7 @@ The endpoint is deliberately field-partial: omitted or empty form values leave t
 | Route | Behavior |
 | --- | --- |
 | `/s/{pid}` | Loads the shield by public ID (`[a-z0-9]{3,128}`) and renders an SVG with `go-badge`. It sets `Cache-Control: no-cache`, so a stable public URL reflects updates promptly. |
-| `/u/{userID}/{shieldKey}` | Loads a shield by its numeric owner ID plus its shield key (`[a-z0-9-]{3,64}`), then renders the same no-cache SVG. |
+| `/u/{login}/{shieldKey}` | Loads a shield by its owner’s GitHub login plus its shield key (`[a-z0-9-]{3,64}`), then renders the same no-cache SVG. |
 | `/s` | Renders an ephemeral SVG from query `title`, `text`, and `color`; default color is `green`. It validates/normalizes color and sends a 30-day cache policy. Nothing is persisted. |
 
 Both endpoints return `image/svg+xml`. The public ID is the lookup key exposed in Markdown; the shield secret is the write credential and never appears in a badge URL.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,6 +90,7 @@ The endpoint is deliberately field-partial: omitted or empty form values leave t
 | Route | Behavior |
 | --- | --- |
 | `/s/{pid}` | Loads the shield by public ID (`[a-z0-9]{3,128}`) and renders an SVG with `go-badge`. It sets `Cache-Control: no-cache`, so a stable public URL reflects updates promptly. |
+| `/u/{userID}/{shieldKey}` | Loads a shield by its numeric owner ID plus its shield key (`[a-z0-9-]{3,64}`), then renders the same no-cache SVG. |
 | `/s` | Renders an ephemeral SVG from query `title`, `text`, and `color`; default color is `green`. It validates/normalizes color and sends a 30-day cache policy. Nothing is persisted. |
 
 Both endpoints return `image/svg+xml`. The public ID is the lookup key exposed in Markdown; the shield secret is the write credential and never appears in a badge URL.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,7 +90,7 @@ The endpoint is deliberately field-partial: omitted or empty form values leave t
 | Route | Behavior |
 | --- | --- |
 | `/s/{pid}` | Loads the shield by public ID (`[a-z0-9]{3,128}`) and renders an SVG with `go-badge`. It sets `Cache-Control: no-cache`, so a stable public URL reflects updates promptly. |
-| `/u/{login}/{shieldKey}` | Loads a shield by its owner’s GitHub login plus its shield key (`[a-z0-9-]{3,64}`), then renders the same no-cache SVG. |
+| `/u/{login}/{shieldKey}` | Loads a shield by its owner’s login (a non-slash path segment up to 255 characters, matching `users.login`) plus its shield key (`[a-z0-9-]{3,64}`), then renders the same no-cache SVG. |
 | `/s` | Renders an ephemeral SVG from query `title`, `text`, and `color`; default color is `green`. It validates/normalizes color and sends a 30-day cache policy. Nothing is persisted. |
 
 Both endpoints return `image/svg+xml`. The public ID is the lookup key exposed in Markdown; the shield secret is the write credential and never appears in a badge URL.

--- a/cmd/shielded/main.go
+++ b/cmd/shielded/main.go
@@ -37,6 +37,8 @@ var (
 	logSource = flag.Bool("log-source", false, "log output includes source code location")
 )
 
+const keyedShieldPath = "/u/{login:[^/]{1,255}}/{shieldKey:[a-z0-9-]{3,64}}"
+
 func init() {
 	flag.Parse()
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
@@ -71,7 +73,7 @@ func main() {
 
 	io := ro.Host(imgHost).Subrouter()
 	io.Handle("/s/{pid:[a-z0-9]{3,128}}", shieldeddotdev.NewShieldHandler(sm))
-	io.Handle("/u/{login:[A-Za-z0-9-]{1,39}}/{shieldKey:[a-z0-9-]{3,64}}", shieldeddotdev.NewKeyedShieldHandler(sm))
+	io.Handle(keyedShieldPath, shieldeddotdev.NewKeyedShieldHandler(sm))
 	io.Handle("/s", &shieldeddotdev.StaticShieldHandler{})
 
 	hosts := pages.Hosts{

--- a/cmd/shielded/main.go
+++ b/cmd/shielded/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	io := ro.Host(imgHost).Subrouter()
 	io.Handle("/s/{pid:[a-z0-9]{3,128}}", shieldeddotdev.NewShieldHandler(sm))
-	io.Handle("/u/{userID:[0-9]+}/{shieldKey:[a-z0-9-]{3,64}}", shieldeddotdev.NewKeyedShieldHandler(sm))
+	io.Handle("/u/{login:[A-Za-z0-9-]{1,39}}/{shieldKey:[a-z0-9-]{3,64}}", shieldeddotdev.NewKeyedShieldHandler(sm))
 	io.Handle("/s", &shieldeddotdev.StaticShieldHandler{})
 
 	hosts := pages.Hosts{

--- a/cmd/shielded/main.go
+++ b/cmd/shielded/main.go
@@ -71,6 +71,7 @@ func main() {
 
 	io := ro.Host(imgHost).Subrouter()
 	io.Handle("/s/{pid:[a-z0-9]{3,128}}", shieldeddotdev.NewShieldHandler(sm))
+	io.Handle("/u/{userID:[0-9]+}/{shieldKey:[a-z0-9-]{3,64}}", shieldeddotdev.NewKeyedShieldHandler(sm))
 	io.Handle("/s", &shieldeddotdev.StaticShieldHandler{})
 
 	hosts := pages.Hosts{

--- a/cmd/shielded/main.go
+++ b/cmd/shielded/main.go
@@ -37,8 +37,6 @@ var (
 	logSource = flag.Bool("log-source", false, "log output includes source code location")
 )
 
-const keyedShieldPath = "/u/{login:[^/]{1,255}}/{shieldKey:[a-z0-9-]{3,64}}"
-
 func init() {
 	flag.Parse()
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
@@ -73,7 +71,7 @@ func main() {
 
 	io := ro.Host(imgHost).Subrouter()
 	io.Handle("/s/{pid:[a-z0-9]{3,128}}", shieldeddotdev.NewShieldHandler(sm))
-	io.Handle(keyedShieldPath, shieldeddotdev.NewKeyedShieldHandler(sm))
+	io.Handle("/u/{login:[^/]{1,255}}/{shieldKey:[a-z0-9-]{3,64}}", shieldeddotdev.NewKeyedShieldHandler(sm))
 	io.Handle("/s", &shieldeddotdev.StaticShieldHandler{})
 
 	hosts := pages.Hosts{

--- a/imghandler.go
+++ b/imghandler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/ShieldedDotDev/shieldeddotdev/model"
 	"github.com/gorilla/mux"
@@ -34,10 +35,45 @@ func (sh *ShieldHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	renderShield(w, s)
+}
+
+type KeyedShieldHandler struct {
+	sm *model.ShieldMapper
+}
+
+func NewKeyedShieldHandler(sm *model.ShieldMapper) *KeyedShieldHandler {
+	return &KeyedShieldHandler{sm}
+}
+
+func (sh *KeyedShieldHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	userID, err := strconv.ParseInt(vars["userID"], 10, 64)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	s, err := sh.sm.GetFromUserIDAndShieldKey(userID, vars["shieldKey"])
+	if err != nil {
+		slog.Info("error fetching shield from user id and shield key", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	if s == nil {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	renderShield(w, s)
+}
+
+func renderShield(w http.ResponseWriter, s *model.Shield) {
 	w.Header().Set("Content-Type", "image/svg+xml")
 	w.Header().Set("Cache-Control", "no-cache")
 
-	err = badge.Render(s.Title, s.Text, badge.Color("#"+s.Color), w)
+	err := badge.Render(s.Title, s.Text, badge.Color("#"+s.Color), w)
 	if err != nil {
 		slog.Error("error rendering shield", slog.Any("error", err))
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/imghandler.go
+++ b/imghandler.go
@@ -24,7 +24,7 @@ func (sh *ShieldHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	s, err := sh.sm.GetFromPublicID(idst)
 	if err != nil {
-		slog.Info("error fetching shield from public id", slog.Any("error", err))
+		slog.Error("error fetching shield from public id", slog.Any("error", err))
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -52,7 +52,7 @@ func (sh *KeyedShieldHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	vars := mux.Vars(r)
 	s, err := sh.sm.GetFromUserLoginAndShieldKey(vars["login"], vars["shieldKey"])
 	if err != nil {
-		slog.Info("error fetching shield from user login and shield key", slog.Any("error", err))
+		slog.Error("error fetching shield from user login and shield key", slog.Any("error", err))
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}

--- a/imghandler.go
+++ b/imghandler.go
@@ -35,7 +35,10 @@ func (sh *ShieldHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	renderShield(w, s)
+	if err := renderShield(w, s); err != nil {
+		slog.Error("error rendering shield", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
 }
 
 type KeyedShieldHandler struct {
@@ -66,19 +69,17 @@ func (sh *KeyedShieldHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	renderShield(w, s)
+	if err := renderShield(w, s); err != nil {
+		slog.Error("error rendering shield", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
 }
 
-func renderShield(w http.ResponseWriter, s *model.Shield) {
+func renderShield(w http.ResponseWriter, s *model.Shield) error {
 	w.Header().Set("Content-Type", "image/svg+xml")
 	w.Header().Set("Cache-Control", "no-cache")
 
-	err := badge.Render(s.Title, s.Text, badge.Color("#"+s.Color), w)
-	if err != nil {
-		slog.Error("error rendering shield", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
+	return badge.Render(s.Title, s.Text, badge.Color("#"+s.Color), w)
 }
 
 type StaticShieldHandler struct{}

--- a/imghandler.go
+++ b/imghandler.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
 
 	"github.com/ShieldedDotDev/shieldeddotdev/model"
 	"github.com/gorilla/mux"
@@ -51,15 +50,9 @@ func NewKeyedShieldHandler(sm *model.ShieldMapper) *KeyedShieldHandler {
 
 func (sh *KeyedShieldHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	userID, err := strconv.ParseInt(vars["userID"], 10, 64)
+	s, err := sh.sm.GetFromUserLoginAndShieldKey(vars["login"], vars["shieldKey"])
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
-		return
-	}
-
-	s, err := sh.sm.GetFromUserIDAndShieldKey(userID, vars["shieldKey"])
-	if err != nil {
-		slog.Info("error fetching shield from user id and shield key", slog.Any("error", err))
+		slog.Info("error fetching shield from user login and shield key", slog.Any("error", err))
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}

--- a/model/shields.go
+++ b/model/shields.go
@@ -104,6 +104,20 @@ func (sm *ShieldMapper) GetFromUserIDAndShieldKey(userID int64, shieldKey string
 	}
 }
 
+func (sm *ShieldMapper) GetFromUserLoginAndShieldKey(login, shieldKey string) (*Shield, error) {
+	sh := &Shield{}
+
+	row := sm.db.QueryRow("SELECT s.shield_id, s.public_id, COALESCE(s.shield_key, '') AS shield_key, s.user_id, s.name, s.title, s.text, s.color, s.secret, s.stamp_created, s.stamp_updated FROM shields AS s INNER JOIN users AS u ON u.user_id = s.user_id WHERE u.login = ? AND s.shield_key = ?", login, shieldKey)
+	switch err := row.Scan(&sh.ShieldID, &sh.PublicID, &sh.ShieldKey, &sh.UserID, &sh.Name, &sh.Title, &sh.Text, &sh.Color, &sh.Secret, &sh.Created, &sh.Updated); err {
+	case sql.ErrNoRows:
+		return nil, nil
+	case nil:
+		return sh, nil
+	default:
+		return nil, err
+	}
+}
+
 func (sm *ShieldMapper) GetFromSecret(secret string) (*Shield, error) {
 	sh := &Shield{}
 

--- a/schema/003_unique_user_login.sql
+++ b/schema/003_unique_user_login.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `users`
+  ADD UNIQUE KEY `unq_users_login` (`login`);


### PR DESCRIPTION
Adds a public image-host route at /u/{login}/{shieldKey}.

It accepts an owner login up to the users.login schema limit, validates the existing shield-key format, looks up the shield by its owner login and key, returns the same no-cache SVG as the public-ID route, and returns 404 when no matching shield exists. A forward-only migration makes non-null users.login values unique so each login identifies one owner.

Shield rendering now returns errors to route handlers. AGENTS.md records the project preference for helpers to return errors so callers can add context, log, and choose the response.